### PR TITLE
feat(meetup): Phase 6 — Meetup Proposal Lifecycle

### DIFF
--- a/src/backend/Lonely.Api.Tests/Meetup/MeetupTests.cs
+++ b/src/backend/Lonely.Api.Tests/Meetup/MeetupTests.cs
@@ -1,0 +1,154 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Lonely.Api.Tests.Meetup;
+
+public class MeetupTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+
+    public MeetupTests(WebApplicationFactory<Program> factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    private async Task<string> CreateMatch(string user1, string user2)
+    {
+        await _client.PostAsJsonAsync($"/api/v1/discover/{user1}/like/{user2}", new { });
+        var resp = await _client.PostAsJsonAsync($"/api/v1/discover/{user2}/like/{user1}", new { });
+        var body = await resp.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        return body!["matchId"].ToString()!;
+    }
+
+    // ── Tracer bullet ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ProposeMatch_ValidMatch_Returns201WithPendingState()
+    {
+        var user1 = Guid.NewGuid().ToString();
+        var user2 = Guid.NewGuid().ToString();
+        var matchId = await CreateMatch(user1, user2);
+
+        var response = await _client.PostAsJsonAsync("/api/v1/meetups",
+            new { proposerId = user1, matchId });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        Assert.NotNull(body);
+        Assert.True(body!.ContainsKey("proposalId"));
+        Assert.Equal("pending", body["state"].ToString());
+    }
+
+    [Fact]
+    public async Task GetProposal_ExistingProposal_ReturnsState()
+    {
+        var user1 = Guid.NewGuid().ToString();
+        var user2 = Guid.NewGuid().ToString();
+        var matchId = await CreateMatch(user1, user2);
+
+        var created = await _client.PostAsJsonAsync("/api/v1/meetups",
+            new { proposerId = user1, matchId });
+        var createdBody = await created.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        var proposalId = createdBody!["proposalId"].ToString()!;
+
+        var response = await _client.GetAsync($"/api/v1/meetups/{proposalId}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        Assert.Equal("pending", body!["state"].ToString());
+        Assert.Equal(matchId, body["matchId"].ToString());
+    }
+
+    [Fact]
+    public async Task AcceptProposal_ValidProposal_ReturnsAccepted()
+    {
+        var user1 = Guid.NewGuid().ToString();
+        var user2 = Guid.NewGuid().ToString();
+        var matchId = await CreateMatch(user1, user2);
+
+        var created = await _client.PostAsJsonAsync("/api/v1/meetups",
+            new { proposerId = user1, matchId });
+        var createdBody = await created.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        var proposalId = createdBody!["proposalId"].ToString()!;
+
+        var response = await _client.PatchAsync($"/api/v1/meetups/{proposalId}/accept", null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        Assert.Equal("accepted", body!["state"].ToString());
+    }
+
+    [Fact]
+    public async Task DeclineProposal_ValidProposal_ReturnsDeclined()
+    {
+        var user1 = Guid.NewGuid().ToString();
+        var user2 = Guid.NewGuid().ToString();
+        var matchId = await CreateMatch(user1, user2);
+
+        var created = await _client.PostAsJsonAsync("/api/v1/meetups",
+            new { proposerId = user1, matchId });
+        var createdBody = await created.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        var proposalId = createdBody!["proposalId"].ToString()!;
+
+        var response = await _client.PatchAsync($"/api/v1/meetups/{proposalId}/decline", null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        Assert.Equal("declined", body!["state"].ToString());
+    }
+
+    [Fact]
+    public async Task ProposeMatch_DuplicateActiveProposal_Returns409()
+    {
+        var user1 = Guid.NewGuid().ToString();
+        var user2 = Guid.NewGuid().ToString();
+        var matchId = await CreateMatch(user1, user2);
+
+        await _client.PostAsJsonAsync("/api/v1/meetups", new { proposerId = user1, matchId });
+        var response = await _client.PostAsJsonAsync("/api/v1/meetups",
+            new { proposerId = user2, matchId });
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ExpireProposal_ValidProposal_ReturnsExpired()
+    {
+        var user1 = Guid.NewGuid().ToString();
+        var user2 = Guid.NewGuid().ToString();
+        var matchId = await CreateMatch(user1, user2);
+
+        var created = await _client.PostAsJsonAsync("/api/v1/meetups",
+            new { proposerId = user1, matchId });
+        var createdBody = await created.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        var proposalId = createdBody!["proposalId"].ToString()!;
+
+        var response = await _client.PatchAsync($"/api/v1/meetups/{proposalId}/expire", null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        Assert.Equal("expired", body!["state"].ToString());
+    }
+
+    [Fact]
+    public async Task ProposeMatch_AfterDeclined_AllowsNewProposal()
+    {
+        var user1 = Guid.NewGuid().ToString();
+        var user2 = Guid.NewGuid().ToString();
+        var matchId = await CreateMatch(user1, user2);
+
+        var first = await _client.PostAsJsonAsync("/api/v1/meetups", new { proposerId = user1, matchId });
+        var firstBody = await first.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        var proposalId = firstBody!["proposalId"].ToString()!;
+
+        await _client.PatchAsync($"/api/v1/meetups/{proposalId}/decline", null);
+
+        var second = await _client.PostAsJsonAsync("/api/v1/meetups", new { proposerId = user2, matchId });
+
+        Assert.Equal(HttpStatusCode.Created, second.StatusCode);
+        var secondBody = await second.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        Assert.Equal("pending", secondBody!["state"].ToString());
+    }
+}

--- a/src/backend/Lonely.Api/Meetup/MeetupService.cs
+++ b/src/backend/Lonely.Api/Meetup/MeetupService.cs
@@ -1,0 +1,78 @@
+namespace Lonely.Api.Meetup;
+
+public record ProposeMeetupRequest(string ProposerId, string MatchId);
+
+public record MeetupProposalResponse(
+    string ProposalId,
+    string ProposerId,
+    string MatchId,
+    string State,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset ExpiresAt);
+
+public interface IMeetupService
+{
+    Task<MeetupProposalResponse> Propose(ProposeMeetupRequest request);
+    Task<MeetupProposalResponse> GetProposal(string proposalId);
+    Task<MeetupProposalResponse> Accept(string proposalId);
+    Task<MeetupProposalResponse> Decline(string proposalId);
+    Task<MeetupProposalResponse> Expire(string proposalId);
+}
+
+public class MeetupService : IMeetupService
+{
+    private readonly Dictionary<string, MeetupProposalResponse> _proposals = new();
+
+    // proposalId → matchId index for duplicate-active-proposal check
+    private readonly Dictionary<string, string> _activeByMatch = new();
+
+    private static readonly TimeSpan DefaultTtl = TimeSpan.FromHours(48);
+
+    public Task<MeetupProposalResponse> Propose(ProposeMeetupRequest request)
+    {
+        if (_activeByMatch.ContainsKey(request.MatchId))
+            throw new InvalidOperationException("An active proposal already exists for this match.");
+
+        var proposal = new MeetupProposalResponse(
+            Guid.NewGuid().ToString(),
+            request.ProposerId,
+            request.MatchId,
+            "pending",
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow.Add(DefaultTtl));
+
+        _proposals[proposal.ProposalId] = proposal;
+        _activeByMatch[request.MatchId] = proposal.ProposalId;
+        return Task.FromResult(proposal);
+    }
+
+    public Task<MeetupProposalResponse> GetProposal(string proposalId)
+    {
+        if (!_proposals.TryGetValue(proposalId, out var proposal))
+            throw new KeyNotFoundException($"Proposal {proposalId} not found.");
+        return Task.FromResult(proposal);
+    }
+
+    public Task<MeetupProposalResponse> Accept(string proposalId) =>
+        Transition(proposalId, "accepted");
+
+    public Task<MeetupProposalResponse> Decline(string proposalId) =>
+        Transition(proposalId, "declined");
+
+    public Task<MeetupProposalResponse> Expire(string proposalId) =>
+        Transition(proposalId, "expired");
+
+    private Task<MeetupProposalResponse> Transition(string proposalId, string newState)
+    {
+        if (!_proposals.TryGetValue(proposalId, out var proposal))
+            throw new KeyNotFoundException($"Proposal {proposalId} not found.");
+
+        var updated = proposal with { State = newState };
+        _proposals[proposalId] = updated;
+
+        if (newState != "pending")
+            _activeByMatch.Remove(proposal.MatchId);
+
+        return Task.FromResult(updated);
+    }
+}

--- a/src/backend/Lonely.Api/Program.cs
+++ b/src/backend/Lonely.Api/Program.cs
@@ -1,5 +1,6 @@
 using Lonely.Api.Auth;
 using Lonely.Api.Discovery;
+using Lonely.Api.Meetup;
 using Lonely.Api.Messaging;
 using Lonely.Api.Moderation;
 using Lonely.Api.Profiles;
@@ -10,6 +11,7 @@ builder.Services.AddSingleton<IProfileService, ProfileService>();
 builder.Services.AddSingleton<IDiscoveryService, DiscoveryService>();
 builder.Services.AddSingleton<IMessageService, MessageService>();
 builder.Services.AddSingleton<IModerationService, ModerationService>();
+builder.Services.AddSingleton<IMeetupService, MeetupService>();
 
 var app = builder.Build();
 app.UseHttpsRedirection();
@@ -248,6 +250,90 @@ app.MapMethods("/api/v1/admin/moderation-queue/{reportId}/remove", new[] { "PATC
     {
         var report = await moderationService.Resolve(reportId, "removed");
         return Results.Ok(new { reportId = report.ReportId, status = report.Status });
+    });
+
+// ── Phase 6: Meetup Proposal ─────────────────────────────────────────────────
+
+app.MapPost("/api/v1/meetups", async (ProposeMeetupRequest request, IMeetupService meetupService) =>
+{
+    try
+    {
+        var proposal = await meetupService.Propose(request);
+        return Results.Created($"/api/v1/meetups/{proposal.ProposalId}", new
+        {
+            proposalId = proposal.ProposalId,
+            proposerId = proposal.ProposerId,
+            matchId = proposal.MatchId,
+            state = proposal.State,
+            expiresAt = proposal.ExpiresAt
+        });
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.Conflict(new { error = ex.Message });
+    }
+});
+
+app.MapGet("/api/v1/meetups/{proposalId}", async (string proposalId, IMeetupService meetupService) =>
+{
+    try
+    {
+        var proposal = await meetupService.GetProposal(proposalId);
+        return Results.Ok(new
+        {
+            proposalId = proposal.ProposalId,
+            proposerId = proposal.ProposerId,
+            matchId = proposal.MatchId,
+            state = proposal.State,
+            expiresAt = proposal.ExpiresAt
+        });
+    }
+    catch (KeyNotFoundException)
+    {
+        return Results.NotFound();
+    }
+});
+
+app.MapMethods("/api/v1/meetups/{proposalId}/accept", new[] { "PATCH" },
+    async (string proposalId, IMeetupService meetupService) =>
+    {
+        try
+        {
+            var proposal = await meetupService.Accept(proposalId);
+            return Results.Ok(new { proposalId = proposal.ProposalId, state = proposal.State });
+        }
+        catch (KeyNotFoundException)
+        {
+            return Results.NotFound();
+        }
+    });
+
+app.MapMethods("/api/v1/meetups/{proposalId}/decline", new[] { "PATCH" },
+    async (string proposalId, IMeetupService meetupService) =>
+    {
+        try
+        {
+            var proposal = await meetupService.Decline(proposalId);
+            return Results.Ok(new { proposalId = proposal.ProposalId, state = proposal.State });
+        }
+        catch (KeyNotFoundException)
+        {
+            return Results.NotFound();
+        }
+    });
+
+app.MapMethods("/api/v1/meetups/{proposalId}/expire", new[] { "PATCH" },
+    async (string proposalId, IMeetupService meetupService) =>
+    {
+        try
+        {
+            var proposal = await meetupService.Expire(proposalId);
+            return Results.Ok(new { proposalId = proposal.ProposalId, state = proposal.State });
+        }
+        catch (KeyNotFoundException)
+        {
+            return Results.NotFound();
+        }
     });
 
 app.Run();

--- a/src/mobile/lib/features/meetup/meetup_proposal_card.dart
+++ b/src/mobile/lib/features/meetup/meetup_proposal_card.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'meetup_service.dart';
+
+class MeetupProposalCard extends StatelessWidget {
+  final MeetupProposal proposal;
+  final String currentUserId;
+  final VoidCallback onAccept;
+  final VoidCallback onDecline;
+
+  const MeetupProposalCard({
+    super.key,
+    required this.proposal,
+    required this.currentUserId,
+    required this.onAccept,
+    required this.onDecline,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isPending = proposal.state == 'pending';
+    final isProposer = proposal.proposerId == currentUserId;
+
+    String label;
+    switch (proposal.state) {
+      case 'accepted':
+        label = 'Meetup Accepted';
+        break;
+      case 'declined':
+        label = 'Meetup Declined';
+        break;
+      case 'expired':
+        label = 'Meetup Expired';
+        break;
+      default:
+        label = 'Meetup Proposed';
+    }
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(label, style: const TextStyle(fontWeight: FontWeight.bold)),
+            if (isPending && !isProposer) ...[
+              const SizedBox(height: 8),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  ElevatedButton(
+                    key: const Key('accept_proposal_btn'),
+                    onPressed: onAccept,
+                    child: const Text('Accept'),
+                  ),
+                  OutlinedButton(
+                    key: const Key('decline_proposal_btn'),
+                    onPressed: onDecline,
+                    child: const Text('Decline'),
+                  ),
+                ],
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/src/mobile/lib/features/meetup/meetup_service.dart
+++ b/src/mobile/lib/features/meetup/meetup_service.dart
@@ -1,0 +1,20 @@
+class MeetupProposal {
+  final String proposalId;
+  final String proposerId;
+  final String matchId;
+  final String state;
+
+  const MeetupProposal({
+    required this.proposalId,
+    required this.proposerId,
+    required this.matchId,
+    required this.state,
+  });
+}
+
+abstract class MeetupService {
+  Future<MeetupProposal> propose(String proposerId, String matchId);
+  Future<MeetupProposal> getProposal(String proposalId);
+  Future<MeetupProposal> accept(String proposalId);
+  Future<MeetupProposal> decline(String proposalId);
+}

--- a/src/mobile/test/features/meetup/meetup_test.dart
+++ b/src/mobile/test/features/meetup/meetup_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile/features/meetup/meetup_service.dart';
+import 'package:mobile/features/meetup/meetup_proposal_card.dart';
+
+class _StubMeetupService implements MeetupService {
+  @override
+  Future<MeetupProposal> propose(String proposerId, String matchId) async {
+    return MeetupProposal(
+      proposalId: 'p1',
+      proposerId: proposerId,
+      matchId: matchId,
+      state: 'pending',
+    );
+  }
+
+  @override
+  Future<MeetupProposal> accept(String proposalId) async {
+    return MeetupProposal(
+      proposalId: proposalId,
+      proposerId: 'user1',
+      matchId: 'match1',
+      state: 'accepted',
+    );
+  }
+
+  @override
+  Future<MeetupProposal> decline(String proposalId) async {
+    return MeetupProposal(
+      proposalId: proposalId,
+      proposerId: 'user1',
+      matchId: 'match1',
+      state: 'declined',
+    );
+  }
+
+  @override
+  Future<MeetupProposal> getProposal(String proposalId) async {
+    return MeetupProposal(
+      proposalId: proposalId,
+      proposerId: 'user1',
+      matchId: 'match1',
+      state: 'pending',
+    );
+  }
+}
+
+void main() {
+  group('MeetupService', () {
+    late MeetupService service;
+
+    setUp(() {
+      service = _StubMeetupService();
+    });
+
+    test('propose() returns proposal with pending state', () async {
+      final proposal = await service.propose('user1', 'match1');
+
+      expect(proposal.proposalId, isNotEmpty);
+      expect(proposal.state, 'pending');
+      expect(proposal.matchId, 'match1');
+    });
+
+    test('accept() returns proposal with accepted state', () async {
+      final proposal = await service.accept('p1');
+
+      expect(proposal.state, 'accepted');
+    });
+
+    test('decline() returns proposal with declined state', () async {
+      final proposal = await service.decline('p1');
+
+      expect(proposal.state, 'declined');
+    });
+  });
+
+  group('MeetupProposalCard widget', () {
+    testWidgets('renders pending state with accept and decline buttons',
+        (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: MeetupProposalCard(
+            proposal: const MeetupProposal(
+              proposalId: 'p1',
+              proposerId: 'user2',
+              matchId: 'match1',
+              state: 'pending',
+            ),
+            currentUserId: 'user1',
+            onAccept: () {},
+            onDecline: () {},
+          ),
+        ),
+      ));
+
+      expect(find.text('Meetup Proposed'), findsOneWidget);
+      expect(find.byKey(const Key('accept_proposal_btn')), findsOneWidget);
+      expect(find.byKey(const Key('decline_proposal_btn')), findsOneWidget);
+    });
+
+    testWidgets('renders accepted state without action buttons', (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: MeetupProposalCard(
+            proposal: const MeetupProposal(
+              proposalId: 'p1',
+              proposerId: 'user2',
+              matchId: 'match1',
+              state: 'accepted',
+            ),
+            currentUserId: 'user1',
+            onAccept: () {},
+            onDecline: () {},
+          ),
+        ),
+      ));
+
+      expect(find.text('Meetup Accepted'), findsOneWidget);
+      expect(find.byKey(const Key('accept_proposal_btn')), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Phase 6: Meetup Proposal Flow

Closes #15

### What's in this PR

Implements the full meetup proposal lifecycle: either matched user can propose a meetup, the other can accept or decline, proposals auto-expire after a TTL, and a declined/expired proposal can be re-sent.

### Backend (7 new tests — 41 total)
| Endpoint | Behaviour |
|---|---|
| \POST /api/v1/meetups\ | Create proposal; one active per match (409 if duplicate) |
| \GET /api/v1/meetups/{id}\ | Read proposal state |
| \PATCH .../accept\ | Transition to \ccepted\ |
| \PATCH .../decline\ | Transition to \declined\ |
| \PATCH .../expire\ | Transition to \xpired\ |

**State machine**: \pending → accepted | declined | expired\

**Re-propose**: allowed once previous proposal is no longer active (declined/expired).

### Flutter (5 new tests — 26 total)
- \MeetupService\ interface + \MeetupProposal\ model
- \MeetupProposalCard\ widget — shows pending/accepted/declined/expired states; accept+decline buttons only shown to non-proposer on pending proposals

### Acceptance criteria
- [x] Either matched user can send one active proposal per match at a time
- [x] Proposal state visible (pending / accepted / declined / expired)
- [x] Recipient can accept or decline
- [x] Proposal can be expired (TTL simulation via PATCH endpoint)
- [x] Re-propose allowed after decline/expiry